### PR TITLE
Add FuseSoC support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@
 *.out
 *.o
 .DS_Store
+build
+fusesoc.log
 

--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 Contains Verilog for controller/observer that is being implemented as part of Bachelors Thesis work under supervision of Dr Shovan Bhaumik, Indian Institute of Technology Patna.
 
 Contact me@hatimak.me for details.
+
+-----
+
+### FuseSoC Usage
+
+Make sure [FuseSoC](https://github.com/olofk/fusesoc) is installed and initialised.
+
+Run simulation with `fusesoc sim [--sim=SIMULATOR] [--testbench=TESTBENCH_MODULE] sigma`. Default simulator is [Icarus](http://iverilog.icarus.com) and default testbench is [`fpu_tb`](test/iverilog/fpu.v).
+
+The `sigma` core needs to be in the `cores_root` list for it to be found. This can be achieved either by supplying an argument with `fusesoc` invocation, like `fusesoc --cores-root ../sigma sim sigma`, or by adding to the `cores_root` list in `~/.config/fusesoc/fusesoc.conf` the path to the directory which holds `sigma.core`. For more information on this, please refer to FuseSoC documentation.

--- a/sigma.core
+++ b/sigma.core
@@ -1,0 +1,28 @@
+CAPI=1
+
+[main]
+name = ::sigma:0
+simulators = icarus
+
+[fileset rtl]
+files =
+ src/verilog/fpu/fpu_add.v
+ src/verilog/fpu/fpu_div.v
+ src/verilog/fpu/fpu_double.v
+ src/verilog/fpu/fpu_exceptions.v
+ src/verilog/fpu/fpu_mul.v
+ src/verilog/fpu/fpu_round.v
+ src/verilog/fpu/fpu_sub.v
+ src/verilog/matrix/matrix_add.v
+ src/verilog/matrix/matrix_mul.v
+file_type = verilogSource
+
+[fileset tb]
+files =
+ test/iverilog/fpu.v
+ test/iverilog/matrix_add.v
+file_type = verilogSource
+usage = sim
+
+[simulator]
+toplevel = fpu_tb


### PR DESCRIPTION
Add FuseSoC support. Run with `fusesoc sim sigma`. Default simulator is icarus and default testbench is fpu_tb. To use another simulator add `--sim=<simulator>` after the `sim` argument. Tested with icarus, modelsim and isim. To run the matrix_add testbench, supply `--testbench=matrix_add_tb` after the sim argument